### PR TITLE
Add WASM support and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ features = [
     'v4',
     'serde',
 ]
-version = '0.7.4'
+version = '0.8.1'
 
 [package]
 authors = ['Kai Schmidt <kaikaliischmidt@gmail.com>']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [dependencies]
 bincode = '1.1.4'
 mashup = '0.1.9'
-rmp-serde = '0.13.7'
-serde = '1.0.98'
-serde_derive = '1.0.98'
-serde_yaml = '0.8.9'
+rmp-serde = '0.14.3'
+serde = '1.0.106'
+serde_derive = '1.0.106'
+serde_yaml = '0.8.11'
 
 [dependencies.uuid]
 features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ serde_yaml = '0.8.11'
 features = [
     'v4',
     'serde',
+    'stdweb',
+    'wasm-bindgen',
 ]
 version = '0.8.1'
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [dependencies]
-bincode = '1.1.4'
+bincode = '1.2.1'
 mashup = '0.1.9'
 rmp-serde = '0.14.3'
 serde = '1.0.106'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -821,7 +821,7 @@ macro_rules! schema {
         schema!(impl $name { $($table: $type),* });
     };
     (impl $name:ident { $($table:ident: $type:ty),* }) => {
-        use rql::mashup::*;
+        use mashup::*;
         mashup! {
             $(
                 mut_name["mut_name" $table] = $table _mut;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,7 @@ impl<T> Default for Id<T> {
 }
 
 impl<T> std::str::FromStr for Id<T> {
-    type Err = uuid::parser::ParseError;
+    type Err = uuid::Error;
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         s.parse::<Uuid>().map(|uuid| Id {
             uuid,


### PR DESCRIPTION
The [uuid](https://github.com/uuid-rs/uuid/blob/master/src/lib.rs#L170) package required some features (`stdweb`,`wasm-bindgen`) to be enabled to be compiled to `target_arch=wasm32`. This pull request enables those features and also updates the versions of other dependencies.